### PR TITLE
Minor change for rever to update conda-forge release

### DIFF
--- a/rever.xsh
+++ b/rever.xsh
@@ -26,7 +26,7 @@ $GITHUB_ORG = 'Billingegroup'
 $GITHUB_REPO = 'bg-mpl-stylesheets'
 
 # conda_forge activity
-$FORGE_FEEDSTOCK_ORG = $GITHUB_ORG
+$FORGE_FEEDSTOCK_ORG = 'conda-forge'
 $FORGE_FEEDSTOCK = 'git@github.com:$FORGE_FEEDSTOCK_ORG/$PROJECT-feedstock.git'
 $FORGE_PROTOCOL = 'ssh'
 $FORGE_SOURCE_URL = 'https://github.com/$GITHUB_ORG/$GITHUB_REPO/releases/download/$VERSION/$PROJECT-$VERSION.tar.gz'


### PR DESCRIPTION
Minor change that should be needed for rever to update the conda-forge release.  

@sbillinge : On this branch, run `$ rever 0.2.0` in the root directory of the project in order to push the new version to the conda-forge release.

Closes #29 