### PR TITLE
Fixed latex error

### DIFF
--- a/bg_mpl_stylesheet/bg_mpl_stylesheet.py
+++ b/bg_mpl_stylesheet/bg_mpl_stylesheet.py
@@ -88,7 +88,7 @@ if find_executable('latex'):
         # text properties #
         ###################
         'text.usetex': True,
-        'text.latex.preamble': [r'\usepackage[cm]{sfmath}'],
+        'text.latex.preamble': r'\usepackage[cm]{sfmath}',
         'mathtext.fontset': 'stixsans'
     }
 


### PR DESCRIPTION
Fixed latex error: "latex was not able to process the followings string: b'lp'". 

Due to an API change in matplotlib 3.5.0, according to the official documentation (https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html?highlight=text%20latex%20preamble),"rcParams["text.latex.preamble"] (default: '') and rcParams["pdf.preamble"] no longer accept non-string values". 