### PR TITLE
Update key and URLs in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ To use the stylesheet, near the beginning your python script type ::
 for example ::
 
         from bg_mpl_stylesheets.styles import all_styles
-        plt.style.use(all_styles["bg-style"])
+        plt.style.use(all_styles["bg_style"])
 
 If you wish to use BillingeGroup stylesheet as the default style for all your plots, please follow these steps.
 

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ bg-mpl-stylesheets
 .. |Black| image:: https://img.shields.io/badge/code_style-black-black
         :target: https://github.com/psf/black
 
-.. |Codecov| image:: https://codecov.io/gh/bg-mpl-stylesheets/bg-mpl-stylesheets/branch/main/graph/badge.svg
-        :target: https://codecov.io/gh/bg-mpl-stylesheets/bg-mpl-stylesheets
+.. |Codecov| image:: https://codecov.io/gh/Billingegroup/bg-mpl-stylesheets/branch/main/graph/badge.svg
+        :target: https://codecov.io/gh/Billingegroup/bg-mpl-stylesheets
 
 .. |Forge| image:: https://img.shields.io/conda/vn/conda-forge/bg-mpl-stylesheets
         :target: https://anaconda.org/conda-forge/bg-mpl-stylesheets
@@ -23,7 +23,7 @@ bg-mpl-stylesheets
         :target: https://pypi.org/project/bg-mpl-stylesheets/
 
 .. |Tracking| image:: https://img.shields.io/badge/issue_tracking-github-blue
-        :target: https://github.com/bg-mpl-stylesheets/bg-mpl-stylesheets/issues
+        :target: https://github.com/Billingegroup/bg-mpl-stylesheets/issues
 
 A package for using Billinge group style files
 
@@ -34,7 +34,7 @@ Citation
 
 If you use bg-mpl-stylesheets in a scientific publication, we would like you to cite this package as
 
-        bg-mpl-stylesheets Package, https://github.com/bg-mpl-stylesheets/bg-mpl-stylesheets
+        bg-mpl-stylesheets Package, https://github.com/Billingegroup/bg-mpl-stylesheets
 
 Installation
 ------------
@@ -69,7 +69,7 @@ and then install the package ::
         pip install bg-mpl-stylesheets
 
 If you prefer to install from sources, after installing the dependencies, obtain the source archive from
-`GitHub <https://github.com/bg-mpl-stylesheets/bg-mpl-stylesheets/>`_. Once installed, ``cd`` into your ``bg-mpl-stylesheets`` directory
+`GitHub <https://github.com/Billingegroup/bg-mpl-stylesheets/>`_. Once installed, ``cd`` into your ``bg-mpl-stylesheets`` directory
 and run the following ::
 
         pip install .
@@ -205,7 +205,7 @@ Support and Contribute
 
 `Diffpy user group <https://groups.google.com/g/diffpy-users>`_ is the discussion forum for general questions and discussions about the use of bg-mpl-stylesheets. Please join the bg-mpl-stylesheets users community by joining the Google group. The bg-mpl-stylesheets project welcomes your expertise and enthusiasm!
 
-If you see a bug or want to request a feature, please `report it as an issue <https://github.com/bg-mpl-stylesheets/bg-mpl-stylesheets/issues>`_ and/or `submit a fix as a PR <https://github.com/bg-mpl-stylesheets/bg-mpl-stylesheets/pulls>`_. You can also post it to the `Diffpy user group <https://groups.google.com/g/diffpy-users>`_. 
+If you see a bug or want to request a feature, please `report it as an issue <https://github.com/Billingegroup/bg-mpl-stylesheets/issues>`_ and/or `submit a fix as a PR <https://github.com/Billingegroup/bg-mpl-stylesheets/pulls>`_. You can also post it to the `Diffpy user group <https://groups.google.com/g/diffpy-users>`_. 
 
 Feel free to fork the project and contribute. To install bg-mpl-stylesheets
 in a development mode, with its sources being directly used by Python
@@ -228,7 +228,9 @@ trying to commit again.
 
 Improvements and fixes are always appreciated.
 
-Before contribuing, please read our `Code of Conduct <https://github.com/bg-mpl-stylesheets/bg-mpl-stylesheets/blob/main/CODE_OF_CONDUCT.rst>`_.
+Before contribuing, please read our `Code of Conduct <https://github.com/Billingegroup/bg-mpl-stylesheets/blob/main/CODE_OF_CONDUCT.rst>`_.
+
+
 
 Contact
 -------

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ To use the stylesheet, near the beginning your python script type ::
 for example ::
 
         from bg_mpl_stylesheets.styles import all_styles
-        plt.style.use(all_styles["bg_style"])
+        plt.style.use(all_styles["bg-style"])
 
 If you wish to use BillingeGroup stylesheet as the default style for all your plots, please follow these steps.
 
@@ -132,7 +132,7 @@ You can also update style parameters locally by using the matplotlib style conte
             plt.ylabel('some numbers')
         plt.show()
 
-Here are a snapshot of values in ``all_styles["bg_style"]`` sheet which you may override with ``rc.parms`` to fine tune things: ::
+Here are a snapshot of values in ``all_styles["bg-style"]`` sheet which you may override with ``rc.parms`` to fine tune things: ::
 
         'lines.linewidth':       2.50,
         'lines.markeredgewidth': 0.25,

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,13 +17,13 @@ bg-mpl-stylesheets is developed by Billinge Group
 and its community contributors.
 
 For a detailed list of contributors see
-https://github.com/bg-mpl-stylesheets/bg-mpl-stylesheets/graphs/contributors.
+https://github.com/Billingegroup/bg-mpl-stylesheets/graphs/contributors.
 
 ============
 Installation
 ============
 
-See the `README <https://github.com/bg-mpl-stylesheets/bg-mpl-stylesheets#installation>`_
+See the `README <https://github.com/Billingegroup/bg-mpl-stylesheets#installation>`_
 file included with the distribution.
 
 =================

--- a/example/color_cycles.py
+++ b/example/color_cycles.py
@@ -5,7 +5,7 @@ from bg_mpl_stylesheets.styles import all_styles
 
 # please read the README about how to install the group plot style package
 # and how to import it and use
-plt.style.use(all_styles["bg_style"])
+plt.style.use(all_styles["bg-style"])
 
 
 x = np.arange(0, 1, 0.01)

--- a/example/plot.py
+++ b/example/plot.py
@@ -5,7 +5,7 @@ from bg_mpl_stylesheets.styles import all_styles
 
 # please read the README about how to install the group plot style package
 # and how to import it and use
-plt.style.use(all_styles["bg_style"])
+plt.style.use(all_styles["bg-style"])
 
 # load PDF data
 r, gcalc, dr, dg, gdiff = loadData("example/CdSe_data.fgr").T

--- a/news/tutorial.rst
+++ b/news/tutorial.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* key name in the style dictionary from all_styles["bg-style"] to all_styles["bg_style"] in README.md
+* URLs referring to the organization in README.md
+
+**Security:**
+
+* <news item>

--- a/news/tutorial.rst
+++ b/news/tutorial.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* <news item>
+* key name in the style dictionary from all_styles["bg_style"] to all_styles["bg-style"]
 
 **Deprecated:**
 
@@ -16,7 +16,6 @@
 
 **Fixed:**
 
-* key name in the style dictionary from all_styles["bg-style"] to all_styles["bg_style"] in README.md
 * URLs referring to the organization in README.md
 
 **Security:**

--- a/src/bg_mpl_stylesheets/styles.py
+++ b/src/bg_mpl_stylesheets/styles.py
@@ -102,7 +102,7 @@ def update_style_with_latex(style):
     return style
 
 
-all_styles = {"bg_style": bg_style}
+all_styles = {"bg-style": bg_style}
 
 for key, style in all_styles.items():
     all_styles.update({key: update_style_with_latex(style)})

--- a/src/bg_mpl_stylesheets/tests/test_bg_mpl_stylesheet.py
+++ b/src/bg_mpl_stylesheets/tests/test_bg_mpl_stylesheet.py
@@ -4,7 +4,7 @@ from bg_mpl_stylesheets import styles
 
 
 def test_update_style_with_latex():
-    actual = styles.update_style_with_latex(styles.all_styles["bg_style"])
+    actual = styles.update_style_with_latex(styles.all_styles["bg-style"])
     expected = expected_style
     assert expected == actual
 


### PR DESCRIPTION
## Problem

The `README.md` was not updated.

`plt.style.use(all_styles["bg-style"])` results in the following key error:

```bash
plt.style.use(all_styles["bg-style"])
E   KeyError: 'bg-style'
```
## Solution

Use `(all_styles["bg_style"])` instead.

Proof:

<img width="634" alt="Screenshot 2024-08-08 at 6 28 47 PM" src="https://github.com/user-attachments/assets/ce4c568b-b0ea-4a0e-8100-f16648d53b07">

## Reference

https://github.com/Billingegroup/bg-mpl-stylesheets/blob/4d2ffc384b7becf7a1929fd9f3f592c85a916408/src/bg_mpl_stylesheets/tests/test_bg_mpl_stylesheet.py#L6C2-L9C12
