### PR TITLE
Add columbia blue to colors

### DIFF
--- a/news/columbia_blue.rst
+++ b/news/columbia_blue.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Columiba blue (#B9D9EB) in Colors
+* Columbia blue (#B9D9EB) as columbia_blue in Colors
 
 **Changed:**
 

--- a/news/columbia_blue.rst
+++ b/news/columbia_blue.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Columiba blue (#B9D9EB) in Colors
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/bg_mpl_stylesheets/colors.py
+++ b/src/bg_mpl_stylesheets/colors.py
@@ -14,6 +14,7 @@ class Colors(str, Enum):
     bg_muted_olive = "#918770"
     bg_beige = "#C09F80"
     bg_grey = "#B0B0B0FF"
+    columbia_blue = "#B9D9EB"
     # Add more colors as needed
 
     @classmethod

--- a/src/bg_mpl_stylesheets/tests/test_colors.py
+++ b/src/bg_mpl_stylesheets/tests/test_colors.py
@@ -18,6 +18,7 @@ from bg_mpl_stylesheets.colors import Colors
         (Colors.bg_muted_olive, "#918770"),
         (Colors.bg_beige, "#C09F80"),
         (Colors.bg_grey, "#B0B0B0FF"),
+        (Colors.columbia_blue, "#B9D9EB"),
     ],
 )
 def test_color_values(hex, expected_hex):


### PR DESCRIPTION
Addressing the new request in https://github.com/Billingegroup/bg-mpl-stylesheets/issues/55

Adding `columbia_blue` under `Colors`