### PR TITLE
Instruct to install Python 3.12 for conda environment in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,13 +60,12 @@ To add "conda-forge" to the conda channels, run the following in a terminal. ::
 We want to install our packages in a suitable conda environment.
 The following creates and activates a new environment named ``bg-mpl-stylesheets_env`` ::
 
-        conda create -n bg-mpl-stylesheets_env bg-mpl-stylesheets
+        conda create -n bg-mpl-stylesheets_env bg-mpl-stylesheets python=3.12
         conda activate bg-mpl-stylesheets_env
 
 Then, to fully install ``bg-mpl-stylesheets`` in our active environment, run ::
 
         conda install --file requirements/examples.txt
-        conda install bg-mpl-stylesheets
 
 To confirm that the installation was successful, type ::
 


### PR DESCRIPTION
To prevent from conda-forge to automatically install Python 3.13 which causes the following issue: https://github.com/Billingegroup/bg-mpl-stylesheets/issues/75