### PR TITLE
Remove usage of `distutils` to support py3.13, drop py3.10

### DIFF
--- a/news/distutils.rst
+++ b/news/distutils.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Support for Python 3.13
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* distutils module, as deprecated in Python 3.13
+* Support for Python 3.10
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ classifiers = [
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',
-        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Scientific/Engineering :: Chemistry',
 ]

--- a/src/bg_mpl_stylesheets/styles.py
+++ b/src/bg_mpl_stylesheets/styles.py
@@ -1,4 +1,4 @@
-from distutils.spawn import find_executable
+from shutil import which
 
 from matplotlib import cycler
 
@@ -89,7 +89,7 @@ bg_style = {
 
 
 def update_style_with_latex(style):
-    if find_executable("latex"):
+    if which("latex"):
         tex = {
             ###################
             # text properties #


### PR DESCRIPTION
Closes #77  #75 