### PR TITLE
build: add python 3.14 support

### DIFF
--- a/news/python-3.14-update.rst
+++ b/news/python-3.14-update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added support for Python 3.14
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Removed support for Python 3.11
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "A package for using Billinge group Matplotlib style files."
 keywords = []
 readme = "README.rst"
-requires-python = ">=3.11, <3.14"
+requires-python = ">=3.12, <3.15"
 classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -25,9 +25,9 @@ classifiers = [
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: Unix',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Scientific/Engineering :: Chemistry',
 ]


### PR DESCRIPTION
@sbillinge ready to review, this package is needed as one of the issue in diffpy.srmise needs this package to plot. So, I updated to `python 3.14`.